### PR TITLE
Fixed typographical error, changed Celcius to Celsius in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # I-am-error
 A bare repo with a known mistake for testing.
 
-It is 38 degrees Celcius in this repo, toasty!
+It is 38 degrees Celsius in this repo, toasty!


### PR DESCRIPTION
thoppe, I've corrected a typo in the documentation of the I-am-error project. If this was intentional or you enjoy living in linguistic squalor please let me know and create an issue on https://github.com/thoppe/orthographic-pedant.
